### PR TITLE
MRG: Additions to fine-calc

### DIFF
--- a/mne/preprocessing/_fine_cal.py
+++ b/mne/preprocessing/_fine_cal.py
@@ -246,7 +246,7 @@ def _adjust_coils(new_z, old_z, all_coils, cal_idx, return_subset):
     this_cosmag = np.dot(rot, all_coils[1][this_sl].T).T
     if return_subset:
         all_coils = (this_rmag, this_cosmag, np.zeros(this_rmag.shape[0], int),
-                     1, [True], {0: this_sl})
+                     1, np.array([True]), {0: this_sl})
         return all_coils
     else:
         all_coils[0][this_sl] = this_rmag

--- a/mne/preprocessing/_fine_cal.py
+++ b/mne/preprocessing/_fine_cal.py
@@ -32,7 +32,7 @@ def calculate_fine_calibration(raw, n_imbalance=3, t_window=10., n_jobs=1,
         imbalance components. Only used if gradiometers are present.
     t_window : float
         Time window to use for surface normal rotation in seconds.
-        Default is 2.
+        Default is 10.
     n_jobs : int | str
         Number of jobs to run in parallel. Can be 'cuda' if scikits.cuda
         is installed properly and CUDA is initialized. Currently this
@@ -142,9 +142,11 @@ def calculate_fine_calibration(raw, n_imbalance=3, t_window=10., n_jobs=1,
         imb = np.zeros((len(info['ch_names']), n_imbalance))
     # Put in appropriate structure
     assert len(np.intersect1d(mag_picks, grad_picks)) == 0
-    imb_cals = [cals[ii] if ii in mag_picks else imb[ii]
+    imb_cals = [np.array([cals[ii]]) if ii in mag_picks else imb[ii]
                 for ii in range(len(info['ch_names']))]
-    fine_cal = dict(ch_names=info['ch_names'], locs=locs, imb_cals=imb_cals)
+    ch_names = [ch_dict['logno'] for ch_dict in info['chs']]
+    fine_cal = dict(ch_names=ch_names, locs=locs, imb_cals=imb_cals)
+
     return fine_cal
 
 
@@ -388,4 +390,14 @@ def write_fine_calibration(fname, calibration):
     """
     _check_fname(fname, overwrite=True)
     check_fname(fname, 'cal', ('.dat',))
-    raise NotImplementedError
+
+    # TODO: Figure out if write or write+binary mode is best
+    with open(fname, 'w') as cal_file:
+        for ci, chan in enumerate(calibration['ch_names']):
+            cal_line = np.concatenate([calibration['locs'][ci],
+                                       calibration['imb_cals'][ci]]).round(6)
+            # Write string containing 1) channel, 2) loc info, 3) calib info
+            cal_str = str(chan) + ' ' + ' '.join(map(lambda x: "%.6f" % x,
+                                                     cal_line))
+
+            cal_file.write(cal_str + '\n')

--- a/mne/preprocessing/_fine_cal.py
+++ b/mne/preprocessing/_fine_cal.py
@@ -391,13 +391,12 @@ def write_fine_calibration(fname, calibration):
     _check_fname(fname, overwrite=True)
     check_fname(fname, 'cal', ('.dat',))
 
-    # TODO: Figure out if write or write+binary mode is best
-    with open(fname, 'w') as cal_file:
+    with open(fname, 'wb') as cal_file:
         for ci, chan in enumerate(calibration['ch_names']):
+            # Write string containing 1) channel, 2) loc info, 3) calib info
             cal_line = np.concatenate([calibration['locs'][ci],
                                        calibration['imb_cals'][ci]]).round(6)
-            # Write string containing 1) channel, 2) loc info, 3) calib info
             cal_str = str(chan) + ' ' + ' '.join(map(lambda x: "%.6f" % x,
                                                      cal_line))
 
-            cal_file.write(cal_str + '\n')
+            cal_file.write((cal_str + '\n').encode('ASCII'))

--- a/mne/preprocessing/tests/test_fine_cal.py
+++ b/mne/preprocessing/tests/test_fine_cal.py
@@ -1,0 +1,39 @@
+# Author: Mark Wronkiewicz <wronk@uw.edu>
+#
+# License: BSD (3-clause)
+
+import os.path as op
+import warnings
+
+from mne.datasets import testing
+from mne.preprocessing._fine_cal import (read_fine_calibration,
+                                         write_fine_calibration)
+from mne.utils import _TempDir, object_hash, run_tests_if_main
+from nose.tools import assert_equal
+
+warnings.simplefilter('always')  # Always throw warnings
+
+# Define fine calibration filepaths
+data_path = testing.data_path(download=False)
+fine_cal_fname = op.join(data_path, 'SSS', 'sss_cal_3053.dat')
+fine_cal_fname_3d = op.join(data_path, 'SSS', 'sss_cal_3053_3d.dat')
+
+
+def test_read_write_fine_cal():
+    """Test round trip reading/writing of fine calibration .dat file"""
+    temp_dir = _TempDir()
+    temp_fname = op.join(temp_dir, 'fine_cal_temp.dat')
+
+    for fname in [fine_cal_fname, fine_cal_fname_3d]:
+        # Load fine calibration file
+        fine_cal_dict = read_fine_calibration(fname)
+
+        # Save temp version of fine calibration file
+        write_fine_calibration(temp_fname, fine_cal_dict)
+        fine_cal_dict_reload = read_fine_calibration(temp_fname)
+
+        # Load temp version of fine calibration file and compare hashes
+        assert_equal(object_hash(fine_cal_dict),
+                     object_hash(fine_cal_dict_reload))
+
+run_tests_if_main()


### PR DESCRIPTION
- [x] Indexing error
- [x] write fine calibration to `.dat` file
- [x] write round trip tests for loading/saving `.dat` files
- [ ] After merging, open PR to update `_read_fine_cal` function within `maxwell.py` to use the new version of the function in `_fine_calc.py` that passes the calib. info in a `dict`